### PR TITLE
Convert server to SSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This is a modular implementation of the Outlook MCP (Model Context Protocol) ser
 - **Modular Structure**: Clean separation of concerns for better maintainability
 - **OData Filter Handling**: Proper escaping and formatting of OData queries
 - **Test Mode**: Simulated responses for testing without real API calls
+- **Streaming SSE Server**: Exposes an HTTP endpoint that streams responses using Server-Sent Events
 
 ## Azure App Registration & Configuration
 
@@ -102,13 +103,13 @@ To configure the server, edit the `config.js` file to change:
 
 ## Running Standalone
 
-You can test the server using:
+Start the server with:
 
 ```bash
-./test-modular-server.sh
+npm start
 ```
 
-This will use the MCP Inspector to directly connect to the server and let you test the available tools.
+Then connect a compatible MCP client to `http://localhost:3000/mcp` using the HTTP + SSE transport.
 
 ## Authentication Flow
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.1.0",
-    "dotenv": "^16.5.0"
+    "dotenv": "^16.5.0",
+    "express": "^5.1.0"
   },
   "devDependencies": {
     "@modelcontextprotocol/inspector": "^0.10.2"


### PR DESCRIPTION
## Summary
- add express and update server to use `SSEServerTransport`
- expose `/mcp` and `/messages` SSE endpoints
- document streaming SSE server usage

## Testing
- `node -c index.js`
- `node index.js` (start and stop)

------
https://chatgpt.com/codex/tasks/task_b_684e08c6c9e48320a6b56117d396c6ab