### PR TITLE
Convert server to SSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This is a modular implementation of the Outlook MCP (Model Context Protocol) ser
 - **Modular Structure**: Clean separation of concerns for better maintainability
 - **OData Filter Handling**: Proper escaping and formatting of OData queries
 - **Test Mode**: Simulated responses for testing without real API calls
+- **Streaming SSE Server**: Exposes an HTTP endpoint that streams responses using Server-Sent Events
 
 ## Azure App Registration & Configuration
 
@@ -102,13 +103,20 @@ To configure the server, edit the `config.js` file to change:
 
 ## Running Standalone
 
-You can test the server using:
+Start the server with:
 
 ```bash
-./test-modular-server.sh
+npm start
 ```
 
-This will use the MCP Inspector to directly connect to the server and let you test the available tools.
+The server listens on port `3499` by default. Set the `PORT` environment
+variable to override this.
+
+Connect a compatible MCP client to `http://localhost:3499/mcp` (or your custom
+port) using the HTTP + SSE transport. The server exposes two endpoints:
+
+- `GET /mcp` to open an SSE connection and start a session
+- `POST /messages?sessionId=<id>` to send client messages
 
 ## Authentication Flow
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@
  * Microsoft Outlook through the Microsoft Graph API.
  */
 const { Server } = require("@modelcontextprotocol/sdk/server/index.js");
-const { StdioServerTransport } = require("@modelcontextprotocol/sdk/server/stdio.js");
+const express = require('express');
+const { SSEServerTransport } = require("@modelcontextprotocol/sdk/server/sse.js");
 const config = require('./config');
 
 // Import module tools
@@ -30,21 +31,22 @@ const TOOLS = [
   // Future modules: contactsTools, etc.
 ];
 
-// Create server with tools capabilities
-const server = new Server(
-  { name: config.SERVER_NAME, version: config.SERVER_VERSION },
-  { 
-    capabilities: { 
-      tools: TOOLS.reduce((acc, tool) => {
-        acc[tool.name] = {};
-        return acc;
-      }, {})
-    } 
-  }
-);
+// Create a server instance configured with our tools
+function createServer() {
+  const server = new Server(
+    { name: config.SERVER_NAME, version: config.SERVER_VERSION },
+    {
+      capabilities: {
+        tools: TOOLS.reduce((acc, tool) => {
+          acc[tool.name] = {};
+          return acc;
+        }, {})
+      }
+    }
+  );
 
-// Handle all requests
-server.fallbackRequestHandler = async (request) => {
+  // Handle all requests
+  server.fallbackRequestHandler = async (request) => {
   try {
     const { method, params, id } = request;
     console.error(`REQUEST: ${method} [${id}]`);
@@ -133,16 +135,51 @@ server.fallbackRequestHandler = async (request) => {
   }
 };
 
+  return server;
+}
+
 // Make the script executable
 process.on('SIGTERM', () => {
-  console.error('SIGTERM received but staying alive');
+  console.error('SIGTERM received, shutting down');
+  process.exit(0);
 });
 
-// Start the server
-const transport = new StdioServerTransport();
-server.connect(transport)
-  .then(() => console.error(`${config.SERVER_NAME} connected and listening`))
-  .catch(error => {
-    console.error(`Connection error: ${error.message}`);
-    process.exit(1);
-  });
+// HTTP server using SSE transport
+const app = express();
+app.use(express.json());
+
+const transports = {};
+
+app.get('/mcp', async (req, res) => {
+  console.error('SSE connection requested');
+  try {
+    const transport = new SSEServerTransport('/messages', res);
+    const sessionId = transport.sessionId;
+    transports[sessionId] = transport;
+    transport.onclose = () => {
+      delete transports[sessionId];
+    };
+
+    const server = createServer();
+    await server.connect(transport);
+  } catch (err) {
+    console.error('Error establishing SSE connection:', err);
+    if (!res.headersSent) res.status(500).send('Error establishing SSE stream');
+  }
+});
+
+app.post('/messages', async (req, res) => {
+  const sessionId = req.query.sessionId;
+  const transport = transports[sessionId];
+  if (!transport) {
+    res.status(404).send('Session not found');
+    return;
+  }
+  await transport.handlePostMessage(req, res, req.body);
+});
+
+// Use a less common default port than 3000 to avoid local conflicts
+const PORT = process.env.PORT || 3499;
+app.listen(PORT, () => {
+  console.error(`${config.SERVER_NAME} listening on port ${PORT}`);
+});

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.1.0",
-    "dotenv": "^16.5.0"
+    "dotenv": "^16.5.0",
+    "express": "^5.1.0"
   },
   "devDependencies": {
     "@modelcontextprotocol/inspector": "^0.10.2"


### PR DESCRIPTION
## Summary
- add express and update server to use `SSEServerTransport`
- expose `/mcp` and `/messages` SSE endpoints
- document streaming SSE server usage
- use port 3499 by default instead of 3000
- clarify SSE endpoints and how to override the listening port

## Testing
- `node -c index.js`
- `node index.js` (start and stop)
- `curl -v -N http://localhost:3499/mcp?test=1`


------
https://chatgpt.com/codex/tasks/task_b_684e08c6c9e48320a6b56117d396c6ab